### PR TITLE
Fix PHP Unit version issue

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": ">=7.0",
         "laravel/framework": "5.5.*",
         "kahlan/kahlan": "^3.0",
-        "phpunit/phpunit" : "~5.0"
+        "phpunit/phpunit" : "~6.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Laravel.php
+++ b/src/Laravel.php
@@ -2,7 +2,8 @@
 
 namespace Sofa\LaravelKahlan;
 
-use PHPUnit_Framework_TestCase;
+//use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Foundation\Testing\Concerns;
 
 /**

--- a/src/Laravel.php
+++ b/src/Laravel.php
@@ -2,14 +2,13 @@
 
 namespace Sofa\LaravelKahlan;
 
-//use PHPUnit_Framework_TestCase;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Foundation\Testing\Concerns;
 
 /**
  * This class is a wrapper for the Laravel's built-in testing features.
  */
-class Laravel extends PHPUnit_Framework_TestCase
+class Laravel extends TestCase
 {
     use Concerns\InteractsWithContainer,
         Concerns\MakesHttpRequests,


### PR DESCRIPTION
When I first required the latest version of laravel-kahlan for Laravel 5.5, I had first had an error with PHP Unit dependency, so I fixed it in the composer.json

Then passing to PHP Unit 6 created a file not found exception so I modified Laravel.php file for modifying the way TestCase class depency is injected.